### PR TITLE
feat: 마이페이지 즐겨찾기 조회/삭제 및 추천 종목 뉴스 TOP3 출력 기능 추가

### DIFF
--- a/backend/django-api/accounts/serializers.py
+++ b/backend/django-api/accounts/serializers.py
@@ -29,6 +29,15 @@ class UserSerializer(serializers.ModelSerializer):
         user.set_password(password)
         user.save()
         return user
+    
+class UserProfileSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = CustomUser
+        fields = [
+            'id', 'email', 'nickname', 'phone',
+            'investment_style', 'investment_period_months',
+            'trading_frequency', 'owned_stocks',
+        ]
 
 # 관리자용 유저 리스트 시리얼라이저
 class UserListSerializer(serializers.ModelSerializer):

--- a/backend/django-api/accounts/views.py
+++ b/backend/django-api/accounts/views.py
@@ -15,7 +15,7 @@ from google.auth.transport import requests as google_requests
 from .models import CustomUser
 from .serializers import (UserSerializer, UserListSerializer,UserUpdateSerializer,
                           PasswordResetCodeRequestSerializer,PasswordResetSerializer,
-                          PasswordChangeSerializer)
+                          PasswordChangeSerializer,UserProfileSerializer)
 from .utils import send_verification_code_email
 
 logger = logging.getLogger(__name__)
@@ -31,7 +31,7 @@ class CurrentUserView(APIView):
     permission_classes = [IsAuthenticated]
 
     def get(self, request):
-        serializer = UserSerializer(request.user)
+        serializer = UserProfileSerializer(request.user)
         return Response(serializer.data, status=status.HTTP_200_OK)
 
 # ✔️ 회원가입

--- a/backend/django-api/aiRecommendRandom5/models.py
+++ b/backend/django-api/aiRecommendRandom5/models.py
@@ -1,9 +1,11 @@
 from django.db import models
+from django.db.models import JSONField
 
 class PredictedStock(models.Model):
     stock_code = models.CharField(max_length=20)
     company_name = models.CharField(max_length=100)
     predicted_label = models.CharField(max_length=10)  # ← 정수 아니고 문자니까 CharField로!
+    positive_news = JSONField(null=True, blank=True)
     created_at = models.DateTimeField()
 
     class Meta:

--- a/backend/django-api/aiRecommendRandom5/views.py
+++ b/backend/django-api/aiRecommendRandom5/views.py
@@ -5,7 +5,11 @@ import random
 
 @api_view(['GET'])
 def aiRecommendRandom5(request):
-    queryset = list(PredictedStock.objects.filter(predicted_label='3').values('stock_code', 'company_name'))
+    queryset = list(
+        PredictedStock.objects.filter(predicted_label='3').values(
+            'stock_code', 'company_name', 'positive_news'  # ✅ 요거 추가!
+        )
+    )
 
     if len(queryset) > 5:
         queryset = random.sample(queryset, 5)

--- a/backend/django-api/chatbot/mymodel/stock_crawling.py
+++ b/backend/django-api/chatbot/mymodel/stock_crawling.py
@@ -67,9 +67,72 @@ def latest_news(stock_name):
     driver.quit()
     return news_data
 
+def fetch_structured_news(stock_name):
+    BASE_DIR = os.path.dirname(os.path.abspath(__file__))
+    DATA_PATH = os.path.join(BASE_DIR, "data", "stock_list.json")
+
+    with open(DATA_PATH, "r", encoding="utf-8") as f:
+        stock_data = json.load(f)
+
+    stock_code = None
+    for item in stock_data:
+        if item["회사명"] == stock_name:
+            stock_code = item["종목코드"]
+            break
+
+    if not stock_code:
+        print(f"❌ 종목명 '{stock_name}'을 찾을 수 없습니다.")
+        return []
+
+    url = f'https://finance.daum.net/quotes/A{stock_code}#news/stock'
+
+    options = Options()
+    options.add_argument("--headless")
+    options.add_argument("--disable-gpu")
+    options.add_argument("--no-sandbox")
+    options.add_argument("--disable-dev-shm-usage")
+    options.add_argument("window-size=1920x1080")
+    options.add_argument("user-agent=Mozilla/5.0")
+
+    driver = webdriver.Chrome(options=options)
+    driver.get(url)
+
+    try:
+        WebDriverWait(driver, 10).until(
+            EC.presence_of_element_located((By.CLASS_NAME, "tableB"))
+        )
+    except:
+        print("뉴스 요소 로딩 실패")
+        driver.quit()
+        return []
+
+    soup = BeautifulSoup(driver.page_source, 'html.parser')
+    news_list = soup.find("div", class_="tableB").find_all("li")
+
+    news_data = []
+
+    for news in news_list:
+        title_tag = news.find("a", class_="tit")
+        summary_tag = news.find("a", class_="txt")
+
+        if title_tag and summary_tag:
+            news_data.append({
+                "title": title_tag.get_text(strip=True),
+                "summary": summary_tag.get_text(strip=True),
+                "url": title_tag.get("href")
+            })
+
+    driver.quit()
+    return news_data
+
 if __name__ == "__main__":
     # 종목이름을 불러와서 종목 코드를 불러온뒤 latest_news에 넣는다
-    news = latest_news("삼성전자")
+    # news = latest_news("삼성전자")
+    # for n in news:
+    #     print("📰", n)
+    # print(len(news))
+    
+    news = fetch_structured_news("삼성전자")
     for n in news:
         print("📰", n)
     print(len(news))

--- a/backend/django-api/favorites/urls.py
+++ b/backend/django-api/favorites/urls.py
@@ -1,10 +1,12 @@
 from django.urls import path, include
 from rest_framework.routers import DefaultRouter
-from .views import FavoriteStockViewSet
+from .views import FavoriteStockViewSet,DeleteFavoriteByCodeView
 
 router = DefaultRouter()
-router.register(r'', FavoriteStockViewSet, basename='favorites')
+router.register(r'', FavoriteStockViewSet, basename='favorites')  # ✅ 요렇게
 
 urlpatterns = [
-    path('', include(router.urls)),
+    path('code/<str:stock_code>/', DeleteFavoriteByCodeView.as_view()),  # 추가!
 ]
+
+urlpatterns += router.urls

--- a/backend/django-api/favorites/views.py
+++ b/backend/django-api/favorites/views.py
@@ -30,4 +30,15 @@ class FavoriteStockViewSet(viewsets.ModelViewSet):
 
         favorite.delete()
         return Response({"detail": f"{favorite.stock_code} 즐겨찾기에서 삭제됨 ✅"}, status=204)
-        
+
+class DeleteFavoriteByCodeView(APIView):
+    permission_classes = [permissions.IsAuthenticated]
+
+    def delete(self, request, stock_code):
+        user = request.user
+        try:
+            fav = FavoriteStock.objects.get(user=user, stock_code=stock_code)
+            fav.delete()
+            return Response({"detail": f"{stock_code} 즐겨찾기 삭제됨 ✅"}, status=204)
+        except FavoriteStock.DoesNotExist:
+            return Response({"error": "해당 즐겨찾기 항목이 없습니다."}, status=404)

--- a/backend/fastapi-stream/app/models/predicted_stock.py
+++ b/backend/fastapi-stream/app/models/predicted_stock.py
@@ -1,6 +1,7 @@
 # app/models/predicted_stock.py
 
-from sqlalchemy import Column, Integer, String, DateTime
+from sqlalchemy import Column, Integer, String, DateTime 
+from sqlalchemy.dialects.postgresql import JSONB
 from app.database import Base
 
 class PredictedStock(Base):
@@ -10,4 +11,5 @@ class PredictedStock(Base):
     stock_code = Column(String, index=True)
     company_name = Column(String)
     predicted_label = Column(String)  # 0~3 예측 클래스
+    positive_news = Column(JSONB, nullable=True)  
     created_at = Column(DateTime)

--- a/backend/fastapi-stream/app/services/stock_predict_service.py
+++ b/backend/fastapi-stream/app/services/stock_predict_service.py
@@ -31,7 +31,7 @@ DJANGO_CRAWLING_PATH = os.path.join(MYMODEL_PATH, "stock_crawling.py")
 
 # ✅ 함수 불러오기
 predict = import_from_file(DJANGO_PREDICT_PATH, "predict")
-latest_news = import_from_file(DJANGO_CRAWLING_PATH, "latest_news")
+latest_news = import_from_file(DJANGO_CRAWLING_PATH, "fetch_structured_news")
 
 # ✅ 핵심 함수: 예측 수행
 def predict_high_volatility_stocks():
@@ -45,27 +45,42 @@ def predict_high_volatility_stocks():
     for stock in stocks:
         company_name = stock["회사명"]
         stock_code = stock["종목코드"]
-        news_list = latest_news(company_name)
+        news_list = latest_news(company_name)  # 이제 dict list임
 
         if not news_list:
             continue
 
-        news_probs_list = []
+        all_probs = []
+        class_3_articles = []
+
         for article in news_list:
-            preds, probs = predict(article)
+            # 🧠 예측 입력용 텍스트 구성
+            text = article["title"] + " " + article["summary"]
+            preds, probs = predict(text)
             pred_class = preds[0]
-            prob_dist = probs[0][:4]  # 4개 클래스 확률만 사용
+            prob_dist = probs[0][:4]
 
-            news_probs_list.append(prob_dist)
+            all_probs.append(prob_dist)
 
-        # 평균 확률로 최종 클래스 선택
-        avg_probs = [sum(p[i] for p in news_probs_list) / len(news_probs_list) for i in range(4)]
+            if pred_class == 3:
+                class_3_articles.append({
+                    "title": article["title"],
+                    "summary": article["summary"],
+                    "url": article["url"],
+                    "prob": float(prob_dist[3])  # 강한 상승이라고 예측한 확률
+                })
+
+        if not all_probs:
+            continue
+
+        avg_probs = [sum(p[i] for p in all_probs) / len(all_probs) for i in range(4)]
         predicted_class = avg_probs.index(max(avg_probs))
 
         results.append({
             "stock_code": stock_code,
             "company": company_name,
             "class_prediction": predicted_class,
+            "positive_news": class_3_articles
         })
 
     return results
@@ -73,24 +88,27 @@ def predict_high_volatility_stocks():
 def run_daily_prediction():
     print("📌 [예측 시작] 고변동성 종목 예측 중...")
     session = SessionLocal()
-    
+
     session.query(PredictedStock).delete()
     session.commit()
-    
+
     results = predict_high_volatility_stocks()
 
     for r in results:
+
+        # ✅ DB 저장
         session.add(PredictedStock(
             stock_code=r["stock_code"],
             company_name=r["company"],
             predicted_label=r["class_prediction"],
+            positive_news=r["positive_news"],
             created_at=datetime.now()
         ))
 
     session.commit()
     session.close()
     print("✅ [예측 완료] DB에 저장됨.")
-
+    
 # ✅ 단독 실행 확인용
 if __name__ == "__main__":
     run_daily_prediction()

--- a/frontend/fivo-client/package-lock.json
+++ b/frontend/fivo-client/package-lock.json
@@ -11,6 +11,7 @@
         "@emotion/react": "^11.14.0",
         "@emotion/styled": "^11.14.0",
         "@fortawesome/fontawesome-svg-core": "^6.7.2",
+        "@fortawesome/free-regular-svg-icons": "^6.7.2",
         "@fortawesome/free-solid-svg-icons": "^6.7.2",
         "@fortawesome/react-fontawesome": "^0.2.2",
         "@headlessui/react": "^2.2.1",
@@ -1209,6 +1210,18 @@
       "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-svg-core/-/fontawesome-svg-core-6.7.2.tgz",
       "integrity": "sha512-yxtOBWDrdi5DD5o1pmVdq3WMCvnobT0LU6R8RyyVXPvFRd2o79/0NCuQoCjNTeZz9EzA9xS3JxNWfv54RIHFEA==",
       "license": "MIT",
+      "dependencies": {
+        "@fortawesome/fontawesome-common-types": "6.7.2"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@fortawesome/free-regular-svg-icons": {
+      "version": "6.7.2",
+      "resolved": "https://registry.npmjs.org/@fortawesome/free-regular-svg-icons/-/free-regular-svg-icons-6.7.2.tgz",
+      "integrity": "sha512-7Z/ur0gvCMW8G93dXIQOkQqHo2M5HLhYrRVC0//fakJXxcF1VmMPsxnG6Ee8qEylA8b8Q3peQXWMNZ62lYF28g==",
+      "license": "(CC-BY-4.0 AND MIT)",
       "dependencies": {
         "@fortawesome/fontawesome-common-types": "6.7.2"
       },

--- a/frontend/fivo-client/package.json
+++ b/frontend/fivo-client/package.json
@@ -13,6 +13,7 @@
     "@emotion/react": "^11.14.0",
     "@emotion/styled": "^11.14.0",
     "@fortawesome/fontawesome-svg-core": "^6.7.2",
+    "@fortawesome/free-regular-svg-icons": "^6.7.2",
     "@fortawesome/free-solid-svg-icons": "^6.7.2",
     "@fortawesome/react-fontawesome": "^0.2.2",
     "@headlessui/react": "^2.2.1",
@@ -33,8 +34,7 @@
     "redux": "^4.0.5",
     "redux-persist": "^6.0.0",
     "redux-thunk": "^3.1.0",
-    "swiper": "^11.0.0",
-    "@fortawesome/free-regular-svg-icons": "^6.7.2"
+    "swiper": "^11.0.0"
   },
   "devDependencies": {
     "@types/react": "^18.0.0",

--- a/frontend/fivo-client/src/pages/AIRcommPage.jsx
+++ b/frontend/fivo-client/src/pages/AIRcommPage.jsx
@@ -99,78 +99,132 @@ const AIRecommPage = () => {
       </div>
 
       {selectedMenu === "TOP5" && (
-        <>
-          <h1 style={{ marginTop: 20 }}>🔥 AI 추천 종목</h1>
-          {loading && <p>불러오는 중...</p>}
-          {error && <p>에러: {error}</p>}
+  <>
+    <h1 style={{ marginTop: 20 }}>🔥 AI 추천 종목</h1>
+    {loading && <p>불러오는 중...</p>}
+    {error && <p>에러: {error}</p>}
 
-          <div className="recommend-cards-container" style={{ display: "flex", gap: "16px", flexWrap: "wrap" }}>
-            {stocks.map((stock) => {
-              const summary = summaries[stock.stock_code];
-              const isSelected = selectedStock?.stock_code === stock.stock_code;
-              const isUp = summary?.change > 0;
-              const changeColor = isUp ? "red" : "blue";
-              const symbol = isUp ? "▲" : "▼";
+    <div
+      className="recommend-cards-container"
+      style={{ display: "flex", gap: "16px", flexWrap: "wrap" }}
+    >
+      {stocks.map((stock) => {
+        const summary = summaries[stock.stock_code];
+        const isSelected = selectedStock?.stock_code === stock.stock_code;
+        const isUp = summary?.change > 0;
+        const changeColor = isUp ? "red" : "blue";
+        const symbol = isUp ? "▲" : "▼";
 
-              return (
+        return (
+          <div
+            key={stock.stock_code}
+            onClick={() => setSelectedStock(stock)}
+            className={`recommend-card ${isSelected ? "selected" : ""}`}
+            style={{
+              padding: "16px",
+              borderRadius: "12px",
+              background: "#fff",
+              boxShadow: "0 4px 12px rgba(0,0,0,0.06)",
+              cursor: "pointer",
+              minWidth: "200px",
+              border: isSelected ? "2px solid #1976d2" : "1px solid #ccc",
+            }}
+          >
+            <div className="card-header" style={{ marginBottom: "8px" }}>
+              <strong>{stock.company_name}</strong>
+              <div style={{ fontSize: "12px", color: "#888" }}>
+                ({stock.stock_code})
+              </div>
+            </div>
+            {summary ? (
+              <>
                 <div
-                  key={stock.stock_code}
-                  onClick={() => setSelectedStock(stock)}
-                  className={`recommend-card ${isSelected ? "selected" : ""}`}
-                  style={{
-                    padding: "16px",
-                    borderRadius: "12px",
-                    background: "#fff",
-                    boxShadow: "0 4px 12px rgba(0,0,0,0.06)",
-                    cursor: "pointer",
-                    minWidth: "200px",
-                    border: isSelected ? "2px solid #1976d2" : "1px solid #ccc",
-                  }}
+                  className="price"
+                  style={{ fontSize: "22px", fontWeight: "bold" }}
                 >
-                  <div className="card-header" style={{ marginBottom: "8px" }}>
-                    <strong>{stock.company_name}</strong>
-                    <div style={{ fontSize: "12px", color: "#888" }}>({stock.stock_code})</div>
-                  </div>
-                  {summary ? (
-                    <>
-                      <div className="price" style={{ fontSize: "22px", fontWeight: "bold" }}>
-                        {Number(summary.price).toLocaleString()}원
-                      </div>
-                      <div className="change-rate" style={{ color: changeColor }}>
-                        {symbol}
-                        {Math.abs(summary.change).toLocaleString()} ({Math.abs(summary.change_rate).toFixed(2)}%)
-                      </div>
-                    </>
-                  ) : (
-                    <div className="price">로딩 중...</div>
-                  )}
+                  {Number(summary.price).toLocaleString()}원
                 </div>
-              );
-            })}
+                <div className="change-rate" style={{ color: changeColor }}>
+                  {symbol}
+                  {Math.abs(summary.change).toLocaleString()} (
+                  {Math.abs(summary.change_rate).toFixed(2)}%)
+                </div>
+              </>
+            ) : (
+              <div className="price">로딩 중...</div>
+            )}
           </div>
+        );
+      })}
+    </div>
 
-          {selectedSummary && (
-            <>
-              <h2 style={{ marginTop: "40px" }}>
-                {selectedStock?.company_name} ({selectedStock?.stock_code})
-              </h2>
-              <StockSummaryCard data={selectedSummary} />
+    {selectedSummary && (
+      <>
+        <h2 style={{ marginTop: "40px" }}>
+          {selectedStock?.company_name} ({selectedStock?.stock_code})
+        </h2>
+        <StockSummaryCard data={selectedSummary} />
 
-              {volatility && profitability && stability && supplyRisk && (
-                <RiskScoreSelector
-                  companyName={selectedStock?.company_name}
-                  scores={{
-                    volatility: volatility.volatility_score,
-                    profitability: profitability.profitability_score,
-                    stability: stability.stability_score,
-                    supplyRisk: supplyRisk.risk_score,
-                  }}
-                />
-              )}
-            </>
-          )}
-        </>
-      )}
+        {volatility && profitability && stability && supplyRisk && (
+          <RiskScoreSelector
+            companyName={selectedStock?.company_name}
+            scores={{
+              volatility: volatility.volatility_score,
+              profitability: profitability.profitability_score,
+              stability: stability.stability_score,
+              supplyRisk: supplyRisk.risk_score,
+            }}
+          />
+        )}
+
+        {/* ✅ 디버깅 코드
+        {console.log("🧪 selectedStock:", selectedStock)}
+        {console.log("🧪 positive_news:", selectedStock?.positive_news)} */}
+
+        {/* ✅ 조건부 렌더링 테스트 */}
+        {selectedStock?.positive_news?.length > 0 && (
+          <div style={{ marginTop: "32px" }}>
+            <h3>📈 상승 확률 높은 뉴스 TOP 3</h3>
+            <ul style={{ paddingLeft: "16px", fontSize: "14px" }}>
+              {[...selectedStock.positive_news]
+                .sort((a, b) => b.prob - a.prob)
+                .slice(0, 3)
+                .map((news, idx) => (
+                  <li key={idx} style={{ marginBottom: "12px" }}>
+                    <a
+                      href={news.url}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      style={{
+                        fontWeight: "bold",
+                        color: "#1976d2",
+                        textDecoration: "none",
+                      }}
+                    >
+                      {news.title}
+                    </a>
+                    <div
+                      style={{
+                        color: "#555",
+                        fontSize: "13px",
+                        marginTop: "4px",
+                      }}
+                    >
+                      {news.summary}
+                    </div>
+                    <div style={{ fontSize: "12px", color: "#999" }}>
+                      상승 확률: {(news.prob * 100).toFixed(2)}%
+                    </div>
+                  </li>
+                ))}
+            </ul>
+          </div>
+        )}
+      </>
+    )}
+  </>
+)}
+
     </section>
   );
 };

--- a/frontend/fivo-client/src/pages/Dashboard.jsx
+++ b/frontend/fivo-client/src/pages/Dashboard.jsx
@@ -21,6 +21,7 @@ import { BarChart2, Bell, UserCheck } from 'lucide-react';
 import { toast } from 'react-toastify';
 import Layout from '../components/Layout';
 import { updateUserInfo, deleteAccount, getCurrentUser, changePassword } from '../services/user';
+import {getFavoriteStocks, deleteFavoriteByCode} from '../services/favoriteApi'
 
 const Dashboard = () => {
   const reduxUser = useSelector((state) => state.auth.user);
@@ -37,6 +38,8 @@ const Dashboard = () => {
   const [newPassword, setNewPassword] = useState('');
   const [newPassword2, setNewPassword2] = useState('');
 
+  const [favorites, setFavorites] = useState([]);
+
   // ✅ 마이페이지 진입 시 유저 정보 직접 불러오기
   useEffect(() => {
     const fetchUser = async () => {
@@ -49,8 +52,41 @@ const Dashboard = () => {
         console.error(e);
       }
     };
+
     fetchUser();
   }, []);
+  
+  useEffect(() => {
+    const fetchFavorites = async () => {
+      try {
+        const res = await getFavoriteStocks();
+        setFavorites(res.data);  // 또는 .results로 변경
+      } catch (e) {
+        toast.error('즐겨찾기 정보를 불러오지 못했습니다.');
+        console.error(e);
+      }
+    };
+  
+    fetchFavorites();
+  }, []);
+
+  const handleDeleteFavorite = async (stockCode) => {
+    const target = favorites.find((f) => f.stock_code === stockCode);
+
+    if (!window.confirm(`${target?.stock_name || stockCode} 즐겨찾기를 삭제할까요?`)) return;
+
+    try {
+      await deleteFavoriteByCode(stockCode);
+      toast.success(`${target?.stock_name || stockCode} 삭제 완료!`);
+  
+      // 목록 갱신
+      setFavorites((prev) => prev.filter((f) => f.stock_code !== stockCode));
+    } catch (e) {
+      toast.error(`삭제 실패: ${e.response?.data?.error || '오류 발생'}`);
+      console.error(e);
+    }
+  };
+  
 
   const handleUpdate = async () => {
     try {
@@ -122,28 +158,58 @@ const Dashboard = () => {
             📊 대시보드 내용
           </Typography>
 
-          <Grid container spacing={3} sx={{ mt: 2 }}>
-            <Grid item xs={12} sm={6} md={4}>
-              <Card className="rounded-2xl shadow-md text-center p-4">
-                <BarChart2 className="mx-auto mb-2" />
-                <Typography variant="subtitle1">통계 보기</Typography>
-              </Card>
-            </Grid>
-            <Grid item xs={12} sm={6} md={4}>
-              <Card className="rounded-2xl shadow-md text-center p-4">
-                <UserCheck className="mx-auto mb-2" />
-                <Typography variant="subtitle1">사용자 목록</Typography>
-              </Card>
-            </Grid>
-            <Grid item xs={12} sm={6} md={4}>
-              <Card className="rounded-2xl shadow-md text-center p-4">
-                <Bell className="mx-auto mb-2" />
-                <Typography variant="subtitle1">알림 설정</Typography>
-              </Card>
-            </Grid>
-          </Grid>
-        </Card>
+          <Typography variant="h6" fontWeight="bold" gutterBottom>
+            📌 나의 투자 프로필
+          </Typography>
 
+          <Typography>👤 투자자 성향: <strong>{reduxUser?.investment_style || '미지정'}</strong></Typography>
+          <Typography>
+            ⏳ 투자 기간: <strong>
+              약 {Math.round((reduxUser?.investment_period_months || 0) / 30)}개월
+            </strong>
+          </Typography>
+          <Typography>📈 매매 빈도: <strong>{reduxUser?.trading_frequency}회/월</strong></Typography>
+
+          <Typography sx={{ mt: 1 }}>📦 보유 종목:</Typography>
+          <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 1, mt: 1 }}>
+            {(typeof reduxUser?.owned_stocks === 'string'
+              ? JSON.parse(reduxUser.owned_stocks)
+              : reduxUser.owned_stocks || []
+            ).map((stock, idx) => (
+              <span key={idx} className="bg-gray-200 dark:bg-gray-700 text-sm rounded-xl px-2 py-1">
+                {stock}
+              </span>
+            ))}
+          </Box>
+          <Typography sx={{ mt: 2 }}>⭐ 즐겨찾기 종목:</Typography>
+          <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 1, mt: 1 }}>
+            {(favorites || []).map((item, idx) => (
+              <Box
+                key={idx}
+                sx={{
+                  display: 'flex',
+                  alignItems: 'center',
+                  backgroundColor: 'lightyellow',
+                  px: 1,
+                  py: 0.5,
+                  borderRadius: '16px',
+                  gap: 0.5,
+                }}
+              >
+                <span>{item.stock_name} ({item.stock_code})</span>
+                <Button
+                  size="small"
+                  variant="text"
+                  color="error"
+                  onClick={() => handleDeleteFavorite(item.stock_code)}
+                >
+                  ✕
+                </Button>
+              </Box>
+            ))}
+          </Box>       
+        </Card>
+        
         {/* ✏️ 회원정보 수정 Dialog */}
         <Dialog open={openEdit} onClose={() => setOpenEdit(false)}>
           <DialogTitle>회원정보 수정</DialogTitle>

--- a/frontend/fivo-client/src/pages/LoginPage.jsx
+++ b/frontend/fivo-client/src/pages/LoginPage.jsx
@@ -22,22 +22,42 @@ const LoginPage = () => {
     e.preventDefault();
     setError('');
     try {
-      const response = await api.post('/api/accounts/login/', { email, password });
-      const { access, refresh, user } = response.data;
+      // ✅ 1. 로그인 요청
+      const res = await api.post('/api/accounts/login/', { email, password });
+      const { access, refresh } = res.data;
 
+      // ✅ 2. 토큰 저장
       localStorage.setItem('accessToken', access);
       localStorage.setItem('refreshToken', refresh);
 
-      dispatch(loginSuccess({ user, access, refresh }));
+      // ✅ 3. 유저 정보 재요청 (/me) - Authorization 헤더 직접 추가
+      const meRes = await api.get('/api/accounts/me/', {
+        headers: {
+          Authorization: `Bearer ${access}`,
+        },
+      });
 
-      if (user.role === 'admin' || user.is_staff) {
+      console.log('✅ 유저 정보:', meRes.data);
+
+      // ✅ 4. Redux 저장
+      dispatch(loginSuccess({
+        user: meRes.data,
+        access,
+        refresh,
+      }));
+
+      toast.success('✅ 로그인 성공!');
+
+      // ✅ 5. 이동
+      if (meRes.data.role === 'admin' || meRes.data.is_staff) {
         navigate('/admin');
       } else {
         navigate('/dashboard');
       }
+
     } catch (err) {
       console.error(err);
-      setError('로그인 실패! 이메일 또는 비밀번호를 확인해주세요.');
+      setError('❌ 로그인 실패! 이메일 또는 비밀번호 확인해주세요.');
     }
   };
 
@@ -78,34 +98,54 @@ const LoginPage = () => {
           <h2>간편 로그인</h2>
           <ul>
             <li>
-              <GoogleLogin
-                onSuccess={async (credentialResponse) => {
-                  const idToken = credentialResponse.credential;
-                  try {
-                    const res = await api.post('/api/accounts/google-login/', {
-                      id_token: idToken,
-                    });
-                    const { user, access, refresh } = res.data;
+            <GoogleLogin
+              onSuccess={async (credentialResponse) => {
+                const idToken = credentialResponse.credential;
+                try {
+                  // 1️⃣ 구글 로그인 요청
+                  const res = await api.post('/api/accounts/google-login/', {
+                    id_token: idToken,
+                  });
 
-                    localStorage.setItem('accessToken', access);
-                    localStorage.setItem('refreshToken', refresh);
+                  const { access, refresh } = res.data;
 
-                    dispatch(loginSuccess({ user, access, refresh }));
-                    toast.success('✅ 구글 로그인 성공!');
+                  // 2️⃣ 토큰 저장
+                  localStorage.setItem('accessToken', access);
+                  localStorage.setItem('refreshToken', refresh);
 
-                    if (user.role === 'admin' || user.is_staff) {
-                      navigate('/admin');
-                    } else {
-                      navigate('/dashboard');
-                    }
-                  } catch (err) {
-                    toast.error('❌ 구글 로그인 실패');
+                  // 3️⃣ 유저 정보 가져오기 (Authorization 수동 설정)
+                  const meRes = await api.get('/api/accounts/me/', {
+                    headers: {
+                      Authorization: `Bearer ${access}`,
+                    },
+                  });
+
+                  // 4️⃣ Redux 저장
+                  dispatch(loginSuccess({
+                    user: meRes.data,
+                    access,
+                    refresh,
+                  }));
+
+                  toast.success('✅ 구글 로그인 성공!');
+
+                  // 5️⃣ 이동
+                  if (meRes.data.role === 'admin' || meRes.data.is_staff) {
+                    navigate('/admin');
+                  } else {
+                    navigate('/dashboard');
                   }
-                }}
-                onError={() => {
-                  toast.error('❌ 구글 로그인에 실패했습니다.');
-                }}
-              />
+
+                } catch (err) {
+                  console.error('❌ 구글 로그인 실패:', err);
+                  toast.error('❌ 구글 로그인 실패!');
+                }
+              }}
+              onError={() => {
+                toast.error('❌ 구글 로그인에 실패했습니다.');
+              }}
+            />
+
             </li>
             <li>
               <a

--- a/frontend/fivo-client/src/services/favoriteApi.js
+++ b/frontend/fivo-client/src/services/favoriteApi.js
@@ -17,3 +17,13 @@ export const getFavorites = async () => {
   const res = await api.get('/api/favorites/');
   return res.data;
 };
+
+// 즐겨찾기 조회
+export const getFavoriteStocks = async () => {
+  return await api.get('/api/favorites/');
+};
+
+// 즐겨찾기 종목 코드로 삭제
+export const deleteFavoriteByCode = async (stockCode) => {
+  return await api.delete(`/api/favorites/code/${stockCode}/`);
+};

--- a/frontend/fivo-client/yarn.lock
+++ b/frontend/fivo-client/yarn.lock
@@ -416,6 +416,13 @@
   dependencies:
     "@fortawesome/fontawesome-common-types" "6.7.2"
 
+"@fortawesome/free-regular-svg-icons@^6.7.2":
+  version "6.7.2"
+  resolved "https://registry.npmjs.org/@fortawesome/free-regular-svg-icons/-/free-regular-svg-icons-6.7.2.tgz"
+  integrity sha512-7Z/ur0gvCMW8G93dXIQOkQqHo2M5HLhYrRVC0//fakJXxcF1VmMPsxnG6Ee8qEylA8b8Q3peQXWMNZ62lYF28g==
+  dependencies:
+    "@fortawesome/fontawesome-common-types" "6.7.2"
+
 "@fortawesome/free-solid-svg-icons@^6.7.2":
   version "6.7.2"
   resolved "https://registry.npmjs.org/@fortawesome/free-solid-svg-icons/-/free-solid-svg-icons-6.7.2.tgz"


### PR DESCRIPTION
📄 작업 개요

마이페이지에서 즐겨찾기 종목 리스트 출력

종목 개별 삭제 처리 (삭제 시 목록 즉시 반영)

AI 추천 종목 선택 시 상승 확률 기준 뉴스 상위 3건 표시

positive_news 필드 구조화 및 정렬 로직 추가

✅ 변경 사항 요약

Django: PredictedStock 모델에 positive_news 필드 JSON 저장 구조 적용

React:

selectedStock.positive_news 조건부 렌더링 추가

뉴스 정렬 후 상위 3건 출력 로직

삭제 버튼 클릭 시 confirm 및 토스트 처리

Axios: /api/stocks/aiRecommendRandom5/ 응답 포맷 확장 고려