### PR TITLE
feat: 사용자 맞춤 예측 결과 DB 저장 기능 구현

### DIFF
--- a/backend/fastapi-stream/app/models/user_predict.py
+++ b/backend/fastapi-stream/app/models/user_predict.py
@@ -1,16 +1,16 @@
-from sqlalchemy import Column, Integer, String, JSON, DateTime
-from database import Base  # 기존 Base 그대로 사용
+from sqlalchemy import Column, Integer, String, DateTime
+from sqlalchemy.dialects.postgresql import JSONB
+from app.database import Base  # 기존 Base 그대로 사용
 
 class UserPredictedStock(Base):
     __tablename__ = "user_predict"
 
     id = Column(Integer, primary_key=True, index=True)
+    user_id = Column(Integer)
     stock_code = Column(String)
     company_name = Column(String)
-    predicted_label = Column(Integer)
-    positive_news = Column(JSON)
-    
-    risk_score = Column(JSON)
-    final_score = Column(JSON)
-    
+    predicted_label = Column(String)
+    positive_news = Column(JSONB, nullable=True)
+    risk_score = Column(JSONB)
+    final_score = Column(JSONB)
     created_at = Column(DateTime)

--- a/backend/fastapi-stream/app/services/calculate_risk_score_for_predict.py
+++ b/backend/fastapi-stream/app/services/calculate_risk_score_for_predict.py
@@ -1,4 +1,3 @@
-
 import os
 import json
 import time
@@ -19,11 +18,26 @@ DATA_DIR = BASE_DIR / "data"
 INPUT_FILE = DATA_DIR / "stock_list_with_sector.json"
 OUTPUT_FILE = DATA_DIR / "stock_with_risk_score.json"
 
-# ✅ 투자자 성향별 가중치
+# ✅ 투자자 성향별 가중치 (영문 명칭)
 WEIGHTS = {
-    "공격형": {"안정성": 0.2, "수익성": 0.4, "변동성": 0.3, "수급": 0.1},
-    "중립형": {"안정성": 0.3, "수익성": 0.3, "변동성": 0.25, "수급": 0.15},
-    "안정형": {"안정성": 0.5, "수익성": 0.3, "변동성": 0.1, "수급": 0.1},
+    "aggressive": {
+        "stability_score": 0.2,
+        "profitability_score": 0.4,
+        "volatility_score": 0.3,
+        "demand_score": 0.1,
+    },
+    "moderate": {
+        "stability_score": 0.3,
+        "profitability_score": 0.3,
+        "volatility_score": 0.25,
+        "demand_score": 0.15,
+    },
+    "conservative": {
+        "stability_score": 0.5,
+        "profitability_score": 0.3,
+        "volatility_score": 0.1,
+        "demand_score": 0.1,
+    },
 }
 
 
@@ -58,10 +72,10 @@ def calculate_risk_score_for_stock(symbol: str, name: str) -> dict:
 
         # 5. 종합 점수 계산
         metric_scores = {
-            "안정성": stability_score,
-            "수익성": profitability_score,
-            "변동성": volatility_score,
-            "수급": demand_score,
+            "stability_score": stability_score,
+            "profitability_score": profitability_score,
+            "volatility_score": volatility_score,
+            "demand_score": demand_score,
         }
 
         final_scores = calculate_final_scores(metric_scores)
@@ -96,10 +110,12 @@ def calculate_and_save_risk_scores(limit: int = None):
 
         result = calculate_risk_score_for_stock(symbol, name)
         if result:
-            stock.update({
-                "리스크_점수": result["risk_scores"],
-                "최종점수": result["final_scores"]
-            })
+            stock.update(
+                {
+                    "risk_scores": result["risk_scores"],
+                    "final_scores": result["final_scores"],
+                }
+            )
             updated_list.append(stock)
             print(f"✅ [{i+1}/{len(stock_list)}] {name} 처리 완료")
         else:

--- a/backend/fastapi-stream/app/services/user_stock_service.py
+++ b/backend/fastapi-stream/app/services/user_stock_service.py
@@ -1,50 +1,179 @@
-from typing import List
-from fastapi import HTTPException
-import os, json
+import os
+import sys
+import json
+import time
+import importlib.util
 from datetime import datetime
-
-from app.models.user_predict import UserPredictedStock
 from app.database import SessionLocal
-from app.services.stock_predict_service import predict_by_sector_selected_stocks  # 모델 예측 로직
+from app.models.user_predict import UserPredictedStock
 from app.services.calculate_risk_score_for_predict import calculate_risk_score_for_stock
 
-def run_sector_prediction_by_codes(codes: List[str]):
-    try:
-        # 1. 상세정보 로딩
-        json_path = os.path.join(os.path.dirname(__file__), "../../../django-api/dummy/stock_list_with_sector.json")
-        with open(json_path, "r", encoding="utf-8") as f:
-            full_stock_data = json.load(f)
+# 📌 현재 이 파일 위치
+BASE_DIR = os.path.dirname(os.path.abspath(__file__))
 
-        # 2. 코드 기준 필터링
-        selected_stocks = [item for item in full_stock_data if item["종목코드"] in codes]
-        if not selected_stocks:
-            raise HTTPException(status_code=404, detail="전달된 종목코드에 해당하는 정보가 없습니다.")
+# ✅ 장고 chatbot/mymodel 경로 (정확하게)
+MYMODEL_PATH = os.path.abspath(
+    os.path.join(BASE_DIR, "../../../django-api/chatbot/mymodel")
+)
 
-        # 3. 예측 실행
-        results = predict_by_sector_selected_stocks(selected_stocks)
+# ✅ 경로를 Python path에 추가 (혹시 모듈 import로 쓸 경우 대비)
+DJANGO_ROOT = os.path.abspath(os.path.join(BASE_DIR, "../../../django-api"))
+sys.path.append(DJANGO_ROOT)
 
-        # 리스크 분석 점수 함수 추가해야함
-        
-        # 4. 저장
-        session = SessionLocal()
-        session.query(UserPredictedStock).delete()
-        session.commit()
 
-        for r in results:
-            session.add(UserPredictedStock(
-                stock_code=r["stock_code"],
-                company_name=r["company"],
+# ✅ 동적 import 함수
+def import_from_file(filepath, function_name):
+    spec = importlib.util.spec_from_file_location("dynamic_module", filepath)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return getattr(module, function_name)
+
+
+# ✅ 함수 경로 지정 및 불러오기
+DJANGO_PREDICT_PATH = os.path.join(MYMODEL_PATH, "predict_stock_news_class.py")
+DJANGO_CRAWLING_PATH = os.path.join(MYMODEL_PATH, "stock_crawling.py")
+predict = import_from_file(DJANGO_PREDICT_PATH, "predict")
+latest_news = import_from_file(DJANGO_CRAWLING_PATH, "fetch_structured_news")
+
+
+# ✅ 코드 ↔ 이름 맵핑 로드 함수
+def load_code_to_name_map():
+    DATA_PATH = os.path.abspath(os.path.join(BASE_DIR, "../data/stock_list.json"))
+    with open(DATA_PATH, "r", encoding="utf-8") as f:
+        stock_data = json.load(f)
+    return {item["종목코드"]: item["회사명"] for item in stock_data}
+
+
+# ✅ 뉴스 기반 예측
+def predict_by_sector_selected_stocks(selected_codes):
+    results = []
+    code_to_name = load_code_to_name_map()
+
+    for stock_code in selected_codes:
+        company_name = code_to_name.get(stock_code)
+        if not company_name:
+            continue
+
+        news_list = latest_news(company_name)
+        if not news_list:
+            continue
+
+        all_probs = []
+        class_3_articles = []
+
+        for article in news_list:
+            text = article["title"] + " " + article["summary"]
+            preds, probs = predict(text)
+            pred_class = preds[0]
+            prob_dist = probs[0][:4]
+            all_probs.append(prob_dist)
+
+            if pred_class == 3:
+                class_3_articles.append(
+                    {
+                        "title": article["title"],
+                        "summary": article["summary"],
+                        "url": article["url"],
+                        "prob": float(prob_dist[3]),
+                    }
+                )
+
+        if not all_probs:
+            continue
+
+        avg_probs = [sum(p[i] for p in all_probs) / len(all_probs) for i in range(4)]
+        predicted_class = avg_probs.index(max(avg_probs))
+
+        results.append(
+            {
+                "stock_code": stock_code,
+                "company": company_name,
+                "class_prediction": predicted_class,
+                "positive_news": class_3_articles,
+            }
+        )
+
+    return results
+
+
+# ✅ 전체 실행 함수
+def run_custom_prediction(user_id: int, selected_codes: list):
+    print(f"📌 [예측 시작] 사용자({user_id}) 선택 종목 예측 중...")
+    session = SessionLocal()
+    results = predict_by_sector_selected_stocks(selected_codes)
+
+    for i, r in enumerate(results):
+        symbol = r["stock_code"]
+        name = r["company"]
+
+        risk_result = calculate_risk_score_for_stock(symbol, name)
+        if risk_result is None:
+            continue
+
+        session.add(
+            UserPredictedStock(
+                user_id=user_id,
+                stock_code=symbol,
+                company_name=name,
                 predicted_label=r["class_prediction"],
                 positive_news=r["positive_news"],
-                risk_score=r["risk_score"],
-                final_score=r["final_score"],
-                created_at=datetime.now()
-            ))
+                risk_score=risk_result["risk_scores"],
+                final_score=risk_result["final_scores"],
+                created_at=datetime.now(),
+            )
+        )
 
-        session.commit()
-        session.close()
+        print(f"✅ [{i + 1}/{len(results)}] {name} 저장 완료")
 
-        return {"status": "ok", "saved_count": len(results)}
+        if (i + 1) % 5 == 0:
+            print("⏱️ 요청 제한으로 1초 대기 중...")
+            time.sleep(1)
 
-    except Exception as e:
-        raise HTTPException(status_code=500, detail=str(e))
+    session.commit()
+    session.close()
+    print(f"🎯 사용자({user_id})의 종목 예측 결과 DB 저장 완료")
+
+
+# ✅ 단독 실행용
+if __name__ == "__main__":
+    test_user_id = 6
+    test_codes = [
+        "302440",
+        "310210",
+        "331920",
+        "127710",
+        "196300",
+        "432980",
+        "456070",
+        "191420",
+        "214390",
+        "187420",
+        "263050",
+        "314130",
+        "217730",
+        "298380",
+        "373110",
+        "182400",
+        "145020",
+        "251120",
+        "288330",
+        "183490",
+        "256840",
+        "143240",
+        "378800",
+        "225220",
+        "214370",
+        "200130",
+        "246710",
+        "207940",
+        "244460",
+        "102940",
+        "950160",
+        "300080",
+        "106190",
+        "114450",
+        "239340",
+        "134580",
+        "475830",
+    ]
+    run_custom_prediction(test_user_id, test_codes)


### PR DESCRIPTION
- 사용자가 선택한 종목 리스트에 대해 뉴스 기반 예측 수행
- 리스크 점수(변동성, 수급, 수익성, 안정성) 계산 및 종합 점수 생성
- positive_news, risk_scores, final_scores 포함하여 UserPredictedStock 테이블에 저장
- 테스트용 user_id = 6 및 종목 37개 예측 실행 예시 추가