### PR TITLE
í° fix: 관리자 페이지 초기 진입 시 /admin/stats로 자동 이동되도록 index 라우트 설정

### DIFF
--- a/backend/django-api/accounts/models.py
+++ b/backend/django-api/accounts/models.py
@@ -55,3 +55,17 @@ class CustomUser(AbstractBaseUser, PermissionsMixin):
 
     def __str__(self):
         return self.email
+    
+class Notification(models.Model):
+    TYPE_CHOICES = (
+        ('notice', '공지'),
+        ('event', '이벤트'),
+    )
+
+    title = models.CharField(max_length=100)
+    message = models.TextField()
+    type = models.CharField(max_length=10, choices=TYPE_CHOICES)
+    created_at = models.DateTimeField(auto_now_add=True)
+
+    def __str__(self):
+        return f"[{self.get_type_display()}] {self.title}"

--- a/backend/django-api/accounts/serializers.py
+++ b/backend/django-api/accounts/serializers.py
@@ -1,6 +1,6 @@
 # 📄 backend/accounts/serializers.py
 from rest_framework import serializers
-from .models import CustomUser
+from .models import CustomUser, Notification
 
 class UserSerializer(serializers.ModelSerializer):
     password2 = serializers.CharField(write_only=True)
@@ -113,3 +113,9 @@ class PasswordChangeSerializer(serializers.Serializer):
 class LoginSerializer(serializers.Serializer):
     email = serializers.EmailField()
     password = serializers.CharField(write_only=True)
+
+# 관리자 알림 설정용 시리얼
+class NotificationSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = Notification
+        fields = '__all__'

--- a/backend/django-api/accounts/urls.py
+++ b/backend/django-api/accounts/urls.py
@@ -15,6 +15,10 @@ from .views import (
     ChangePasswordView,
     GoogleLoginView,
     admin_user_stats,
+    notification_list_create,
+    public_notifications,
+    update_notification,
+    delete_notification,
 )
 
 app_name = 'accounts'
@@ -35,5 +39,9 @@ urlpatterns = [
     path('users/<int:user_id>/update/', update_user, name='update_user'),
     path('health/', health_check, name='health_check'),  
     path('admin/stats/', admin_user_stats),  # 어드민 페이지의 통계
+    path('admin/notifications/', notification_list_create),  # 어드민 알림 설정
+    path('notifications/public/', public_notifications),
+    path('admin/notifications/<int:notification_id>/update/', update_notification),
+    path('admin/notifications/<int:notification_id>/delete/', delete_notification),
     path('api/stocks/', include('userRecommend.urls')),
 ]

--- a/backend/django-api/accounts/views.py
+++ b/backend/django-api/accounts/views.py
@@ -15,10 +15,11 @@ from django.utils.crypto import get_random_string
 from google.oauth2 import id_token
 from google.auth.transport import requests as google_requests
 
-from .models import CustomUser
+from .models import CustomUser,Notification
 from .serializers import (UserSerializer, UserListSerializer,UserUpdateSerializer,
                           PasswordResetCodeRequestSerializer,PasswordResetSerializer,
-                          PasswordChangeSerializer,UserProfileSerializer, LoginSerializer,)
+                          PasswordChangeSerializer,UserProfileSerializer, LoginSerializer,
+                          NotificationSerializer)
 from .utils import send_verification_code_email
 from drf_yasg.utils import swagger_auto_schema
 
@@ -347,3 +348,57 @@ def admin_user_stats(request):
         "verification_rate": verification_rate,
         "daily_signups": daily_counts,
     }, status=status.HTTP_200_OK)
+
+# ✔️ 관리자 전용 - 알림 작성 및 전체 조회
+@api_view(['GET', 'POST'])
+@permission_classes([IsAdminUser])
+def notification_list_create(request):
+    if request.method == 'GET':
+        noti = Notification.objects.order_by('-created_at')
+        serializer = NotificationSerializer(noti, many=True)
+        return Response(serializer.data)
+
+    if request.method == 'POST':
+        serializer = NotificationSerializer(data=request.data)
+        if serializer.is_valid():
+            serializer.save()
+            return Response(serializer.data, status=status.HTTP_201_CREATED)
+        return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
+    
+@api_view(['GET'])
+@permission_classes([AllowAny])  # 또는 IsAuthenticated
+def public_notifications(request):
+    notis = Notification.objects.order_by('-created_at')[:10]
+    serializer = NotificationSerializer(notis, many=True)
+    return Response(serializer.data)
+
+# ✔️ 관리자 전용 - 알림 수정 (PATCH)
+@api_view(['PATCH'])
+@permission_classes([IsAdminUser])
+def update_notification(request, notification_id):
+    try:
+        from .models import Notification
+        from .serializers import NotificationSerializer
+
+        noti = Notification.objects.get(id=notification_id)
+    except Notification.DoesNotExist:
+        return Response({"error": "해당 알림이 존재하지 않습니다."}, status=404)
+
+    serializer = NotificationSerializer(noti, data=request.data, partial=True)
+    if serializer.is_valid():
+        serializer.save()
+        return Response(serializer.data)
+    return Response(serializer.errors, status=400)
+
+
+# ✔️ 관리자 전용 - 알림 삭제 (DELETE)
+@api_view(['DELETE'])
+@permission_classes([IsAdminUser])
+def delete_notification(request, notification_id):
+    try:
+        from .models import Notification
+        noti = Notification.objects.get(id=notification_id)
+        noti.delete()
+        return Response({"message": "삭제 완료!"}, status=204)
+    except Notification.DoesNotExist:
+        return Response({"error": "해당 알림이 존재하지 않습니다."}, status=404)

--- a/frontend/fivo-client/src/App.jsx
+++ b/frontend/fivo-client/src/App.jsx
@@ -50,10 +50,6 @@ const router = createBrowserRouter(
         }
       />
 
-      {/* ✅ 관리자 진입 시 /admin → /admin/stats 로 리디렉션
-      뺸 이유 : 이러면 관리자 전용 섹션으로 진입불가라서
-      <Route path="admin" element={<Navigate to="admin/stats" replace />} /> */}
-
       {/* ✅ 관리자 전용 섹션 */}
       <Route
         path="admin"
@@ -63,6 +59,9 @@ const router = createBrowserRouter(
           </RequireAuth>
         }
       >
+        {/* ✅ 관리자 진입 시 /admin → /admin/stats 로 리디렉션
+        뺸 이유 : 이러면 관리자 전용 섹션으로 진입불가라서 */}
+        <Route index element={<Navigate to="/admin/stats" replace />} />
         <Route path="stats" element={<AdminStats />} />
         <Route path="users" element={<AdminUsers />} />
         <Route path="notifications" element={<AdminNotifications />} />

--- a/frontend/fivo-client/src/components/LoginStateMenus.css
+++ b/frontend/fivo-client/src/components/LoginStateMenus.css
@@ -1,0 +1,34 @@
+.notification-menu {
+    position: relative;
+    cursor: pointer;
+  }
+  
+  .notification-dropdown {
+    position: absolute;
+    right: 0;
+    top: 40px;
+    width: 250px;
+    background: white;
+    border: 1px solid #ccc;
+    border-radius: 10px;
+    z-index: 999;
+    box-shadow: 0 4px 8px rgba(0,0,0,0.1);
+    padding: 10px;
+  }
+  
+  .notification-dropdown .dropdown-title {
+    font-weight: bold;
+    margin-bottom: 8px;
+  }
+  
+  .notification-item {
+    padding: 5px 0;
+    font-size: 14px;
+    border-bottom: 1px solid #eee;
+  }
+  
+  .notification-empty {
+    font-size: 13px;
+    color: #888;
+  }
+  

--- a/frontend/fivo-client/src/components/LoginStateMenus.jsx
+++ b/frontend/fivo-client/src/components/LoginStateMenus.jsx
@@ -1,46 +1,105 @@
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faBell as farBell, faCircleUser as farCircleUser } from '@fortawesome/free-regular-svg-icons';
 import { NavLink, useNavigate } from 'react-router-dom';
 import { logout } from '../slices/authSlice';
-import { useDispatch,useSelector } from 'react-redux';
-
+import { useDispatch, useSelector } from 'react-redux';
+import api from '../services/api'; // axios 래퍼
+import './LoginStateMenus.css'; // 드롭다운 스타일용
+import {
+  Dialog,
+  DialogTitle,
+  DialogContent,
+  DialogActions,
+  Button,
+  Typography,
+} from '@mui/material';
 
 const LoginStateMenus = () => {
   const [menuOpen, setMenuOpen] = useState(false);
+  const [notiOpen, setNotiOpen] = useState(false);
+  const [notifications, setNotifications] = useState([]);
+  const [selectedNoti, setSelectedNoti] = useState(null);
   const user = useSelector((state) => state.auth.user);
   const dispatch = useDispatch();
   const navigate = useNavigate();
+
+  const fetchNotifications = async () => {
+    try {
+      const res = await api.get('/api/accounts/notifications/public/');
+      setNotifications(res.data);
+    } catch (err) {
+      console.error('🔔 알림 불러오기 실패', err);
+    }
+  };
+
+  useEffect(() => {
+    fetchNotifications();
+  }, []);
+
   return (
     <>
-      <li className='my-menu' onClick={() => setMenuOpen((prevState) => !prevState)}>
-       
-        <FontAwesomeIcon icon={farCircleUser}/>
-        
-        <div className={`my-sub-menu`}>
-          <NavLink to={user?.is_staff ? "/admin/stats" : "/dashboard"}>
-            {user?.is_staff ? "관리페이지" : "마이페이지"}
-          </NavLink>
-          <button
-            type='button'
-            className="logout-btn"
-            color="error"
-            onClick={() => {
-            console.log('🚀 로그아웃 클릭됨');
-            dispatch(logout());
-            setTimeout(() => {
-              navigate('/', { replace: true });
-            }, 0);
-            }}
-          >
-            로그아웃
-          </button>
-
-        </div>
+      {/* 🔵 유저 메뉴 */}
+      <li className="my-menu" onClick={() => setMenuOpen((prev) => !prev)}>
+        <FontAwesomeIcon icon={farCircleUser} />
+        {menuOpen && (
+          <div className="my-sub-menu">
+            <NavLink to={user?.is_staff ? "/admin/stats" : "/dashboard"}>
+              {user?.is_staff ? "관리페이지" : "마이페이지"}
+            </NavLink>
+            <button
+              type="button"
+              className="logout-btn"
+              onClick={() => {
+                console.log('🚀 로그아웃 클릭됨');
+                dispatch(logout());
+                setTimeout(() => navigate('/', { replace: true }), 0);
+              }}
+            >
+              로그아웃
+            </button>
+          </div>
+        )}
       </li>
-      <li><FontAwesomeIcon icon={farBell}/></li>
+
+      {/* 🔔 알림 아이콘 */}
+      <li className="notification-menu" onClick={() => setNotiOpen((prev) => !prev)}>
+        <FontAwesomeIcon icon={farBell} />
+        {notiOpen && (
+          <div className="notification-dropdown">
+            <p className="dropdown-title">📢 최근 알림</p>
+            {notifications.length > 0 ? (
+                notifications.slice(0, 5).map((n) => (
+                  <div
+                    key={n.id}
+                    className="notification-item"
+                    onClick={() => setSelectedNoti(n)} // ✅ 클릭 시 선택
+                    style={{ cursor: 'pointer' }}
+                  >
+                    <strong>[{n.type === 'notice' ? '공지' : '이벤트'}]</strong> {n.title}
+                  </div>
+                ))
+              ) : (
+                <p className="notification-empty">알림이 없습니다.</p>
+            )}
+          </div>
+        )}
+      </li>
+      <Dialog open={!!selectedNoti} onClose={() => setSelectedNoti(null)}>
+        <DialogTitle>
+          [{selectedNoti?.type === 'notice' ? '공지' : '이벤트'}] {selectedNoti?.title}
+        </DialogTitle>
+        <DialogContent dividers>
+          <Typography style={{ whiteSpace: 'pre-line' }}>
+            {selectedNoti?.message}
+          </Typography>
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={() => setSelectedNoti(null)}>닫기</Button>
+        </DialogActions>
+      </Dialog>
     </>
   );
-}
+};
 
 export default LoginStateMenus;

--- a/frontend/fivo-client/src/pages/AdminNotifications.jsx
+++ b/frontend/fivo-client/src/pages/AdminNotifications.jsx
@@ -1,10 +1,223 @@
-// 📄 src/pages/AdminNotifications.jsx
+import { useEffect, useState } from 'react';
+import {
+  Typography,
+  TextField,
+  Button,
+  Box,
+  Paper,
+  Table,
+  TableHead,
+  TableRow,
+  TableCell,
+  TableBody,
+} from '@mui/material';
+import {
+  Dialog,
+  DialogTitle,
+  DialogContent,
+  DialogActions,
+} from '@mui/material';
+import axios from 'axios';
+import DeleteIcon from '@mui/icons-material/Delete';
+import EditIcon from '@mui/icons-material/Edit';
+
 const AdminNotifications = () => {
+  const [notiTitle, setNotiTitle] = useState('');
+  const [notiMessage, setNotiMessage] = useState('');
+  const [notiType, setNotiType] = useState('notice');
+  const [notifications, setNotifications] = useState([]);
+  const [editTarget, setEditTarget] = useState(null);
+  const [editTitle, setEditTitle] = useState('');
+  const [editMessage, setEditMessage] = useState('');
+
+  const fetchNotifications = async () => {
+    try {
+      const token = localStorage.getItem('accessToken');
+      const res = await axios.get('/api/accounts/admin/notifications/', {
+        headers: { Authorization: `Bearer ${token}` },
+      });
+      setNotifications(res.data);
+    } catch (err) {
+      console.error('🔔 알림 조회 실패', err);
+    }
+  };
+
+  const handleCreateNotification = async (e) => {
+    e.preventDefault();
+    try {
+      const token = localStorage.getItem('accessToken');
+      await axios.post(
+        '/api/accounts/admin/notifications/',
+        {
+          title: notiTitle,
+          message: notiMessage,
+          type: notiType,
+        },
+        {
+          headers: { Authorization: `Bearer ${token}` },
+        }
+      );
+      setNotiTitle('');
+      setNotiMessage('');
+      setNotiType('notice');
+      fetchNotifications();
+    } catch (err) {
+      console.error('❌ 알림 등록 실패', err);
+    }
+  };
+
+  const handleEdit = (noti) => {
+    setEditTarget(noti);
+    setEditTitle(noti.title);
+    setEditMessage(noti.message);
+  };
+  
+  const handleEditSubmit = async () => {
+    try {
+      const token = localStorage.getItem('accessToken');
+      await axios.patch(
+        `/api/accounts/admin/notifications/${editTarget.id}/update/`,
+        { title: editTitle, message: editMessage },
+        { headers: { Authorization: `Bearer ${token}` } }
+      );
+      setEditTarget(null);
+      fetchNotifications();
+    } catch (err) {
+      console.error('✏️ 수정 실패:', err);
+    }
+  };
+  
+  const handleDelete = async (id) => {
+    if (!window.confirm('이 알림을 삭제할까요?')) return;
+    try {
+      const token = localStorage.getItem('accessToken');
+      await axios.delete(`/api/accounts/admin/notifications/${id}/delete/`, {
+        headers: { Authorization: `Bearer ${token}` },
+      });
+      fetchNotifications();
+    } catch (err) {
+      console.error('🗑 삭제 실패:', err);
+    }
+  };
+
+  useEffect(() => {
+    fetchNotifications();
+  }, []);
+
   return (
-    <div>
-      <h2>🔔 관리자 기능: 알림 설정</h2>
-      <p>공지사항, 이벤트 알림 등을 전체 사용자에게 발송하고 관리할 수 있는 기능입니다.</p>
-    </div>
+    <Box className="p-6">
+      <Typography variant="h5" fontWeight="bold" gutterBottom>
+        🔔 관리자 기능: 알림 설정
+      </Typography>
+      <Typography variant="body2" mb={3}>
+        공지사항, 이벤트 알림 등을 전체 사용자에게 발송하고 관리할 수 있는 기능입니다.
+      </Typography>
+
+      {/* 알림 작성 폼 */}
+      <Box component="form" onSubmit={handleCreateNotification} sx={{ mb: 4 }}>
+        <TextField
+          label="제목"
+          variant="outlined"
+          fullWidth
+          margin="normal"
+          value={notiTitle}
+          onChange={(e) => setNotiTitle(e.target.value)}
+          required
+        />
+        <TextField
+          label="내용"
+          variant="outlined"
+          fullWidth
+          multiline
+          rows={4}
+          margin="normal"
+          value={notiMessage}
+          onChange={(e) => setNotiMessage(e.target.value)}
+          required
+        />
+        <TextField
+          label="알림 종류"
+          select
+          fullWidth
+          margin="normal"
+          value={notiType}
+          onChange={(e) => setNotiType(e.target.value)}
+          SelectProps={{ native: true }}
+        >
+          <option value="notice">공지</option>
+          <option value="event">이벤트</option>
+        </TextField>
+        <Button type="submit" variant="contained" color="primary">
+          알림 등록
+        </Button>
+      </Box>
+
+      {/* 알림 리스트 */}
+      <Typography variant="h6" gutterBottom>📋 등록된 알림</Typography>
+      <Paper elevation={2}>
+        <Table>
+          <TableHead>
+            <TableRow>
+              <TableCell>종류</TableCell>
+              <TableCell>제목</TableCell>
+              <TableCell>내용</TableCell>
+              <TableCell>작성일</TableCell>
+            </TableRow>
+          </TableHead>
+          <TableBody>
+            {notifications.length > 0 ? (
+              notifications.map((n) => (
+                <TableRow key={n.id}>
+                  <TableCell>{n.type === "notice" ? "공지" : "이벤트"}</TableCell>
+                  <TableCell>{n.title}</TableCell>
+                  <TableCell>{n.message}</TableCell>
+                  <TableCell>{new Date(n.created_at).toLocaleString()}</TableCell>
+                  <TableCell align="right">
+                    <Button size="small" onClick={() => handleEdit(n)}>
+                      <EditIcon fontSize="small" />
+                    </Button>
+                    <Button size="small" color="error" onClick={() => handleDelete(n.id)}>
+                      <DeleteIcon fontSize="small" />
+                    </Button>
+                  </TableCell>
+                </TableRow>
+              ))
+            ) : (
+              <TableRow>
+                <TableCell colSpan={5} align="center">등록된 알림이 없습니다.</TableCell>
+              </TableRow>
+            )}
+          </TableBody>
+        </Table>
+      </Paper>
+      <Dialog open={!!editTarget} onClose={() => setEditTarget(null)}>
+        <DialogTitle>🔁 알림 수정</DialogTitle>
+        <DialogContent dividers>
+          <TextField
+            label="제목"
+            fullWidth
+            margin="normal"
+            value={editTitle}
+            onChange={(e) => setEditTitle(e.target.value)}
+          />
+          <TextField
+            label="내용"
+            fullWidth
+            multiline
+            rows={4}
+            margin="normal"
+            value={editMessage}
+            onChange={(e) => setEditMessage(e.target.value)}
+          />
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={() => setEditTarget(null)}>취소</Button>
+          <Button onClick={handleEditSubmit} variant="contained" color="primary">
+            저장
+          </Button>
+        </DialogActions>
+      </Dialog>
+    </Box>
   );
 };
 

--- a/frontend/fivo-client/src/pages/AdminPage.jsx
+++ b/frontend/fivo-client/src/pages/AdminPage.jsx
@@ -25,9 +25,12 @@ import Layout from '../components/Layout';
 import { useDispatch } from 'react-redux';
 import { logout } from '../auth/authSlice';
 import { useNavigate } from 'react-router-dom';
+import AdminStats from './AdminStats';
+import AdminNotifications from './AdminNotifications';
 
 const AdminPage = () => {
-  const [tab, setTab] = useState(0);
+  const [tab, setTab] = useState(null); // ✅ 초기 null
+  const [ready, setReady] = useState(false); // ✅ 렌더링 준비 상태
   const [users, setUsers] = useState([]);
   const [filteredUsers, setFilteredUsers] = useState([]);
   const [loading, setLoading] = useState(false);
@@ -67,14 +70,11 @@ const AdminPage = () => {
         setUsers(response.data);
         setFilteredUsers(response.data);
       } else {
-        console.error("응답 데이터가 배열이 아님:", response.data);
         setUsers([]);
         setFilteredUsers([]);
       }
     } catch (error) {
-      console.error('유저 목록 가져오기 실패:', error);
       if (error.response?.status === 401 || error.response?.status === 403) {
-        // 인증 실패 → 로그인으로 튕기기
         localStorage.removeItem('accessToken');
         navigate('/login');
       } else {
@@ -91,6 +91,8 @@ const AdminPage = () => {
     if (!token) {
       navigate('/login');
     }
+    setTab(0); // ✅ 탭 초기값 설정
+    setReady(true); // ✅ 렌더링 준비 완료
   }, []);
 
   useEffect(() => {
@@ -100,13 +102,11 @@ const AdminPage = () => {
   }, [tab]);
 
   useEffect(() => {
-    const filtered = Array.isArray(users)
-      ? users.filter(
-          (user) =>
-            user.email.toLowerCase().includes(search.toLowerCase()) ||
-            user.nickname.toLowerCase().includes(search.toLowerCase())
-        )
-      : [];
+    const filtered = users.filter(
+      (user) =>
+        user.email.toLowerCase().includes(search.toLowerCase()) ||
+        user.nickname.toLowerCase().includes(search.toLowerCase())
+    );
     setFilteredUsers(filtered);
   }, [search, users]);
 
@@ -122,31 +122,25 @@ const AdminPage = () => {
           </Button>
         </Box>
 
-        <Paper elevation={1} className="rounded-xl overflow-hidden">
-          <Tabs
-            value={tab}
-            onChange={handleTabChange}
-            indicatorColor="primary"
-            textColor="primary"
-            centered
-          >
-            <Tab label="📊 통계 보기" />
-            <Tab label="👥 사용자 목록" />
-            <Tab label="🔔 알림 설정" />
-          </Tabs>
-        </Paper>
-
-        {/* 탭 콘텐츠 */}
-        {tab === 0 && (
-          <Box mt={4}>
-            <Typography variant="h6">📈 통계 영역 준비 중...</Typography>
-            <Typography variant="body2" color="text.secondary">
-              누적 가입자, 일간 가입자, 인증 완료 비율 등 시각화 예정
-            </Typography>
-          </Box>
+        {ready && (
+          <Paper elevation={1} className="rounded-xl overflow-hidden">
+            <Tabs
+              value={tab}
+              onChange={handleTabChange}
+              indicatorColor="primary"
+              textColor="primary"
+              centered
+            >
+              <Tab label="📊 통계 보기" />
+              <Tab label="👥 사용자 목록" />
+              <Tab label="🔔 알림 설정" />
+            </Tabs>
+          </Paper>
         )}
 
-        {tab === 1 && (
+        {ready && tab === 0 && <AdminStats />}
+
+        {ready && tab === 1 && (
           <Box mt={4}>
             <TextField
               label="사용자 검색"
@@ -244,14 +238,7 @@ const AdminPage = () => {
           </Box>
         )}
 
-        {tab === 2 && (
-          <Box mt={4}>
-            <Typography variant="h6">🔔 알림 설정 기능 준비 중</Typography>
-            <Typography variant="body2" color="text.secondary">
-              사용자 대상 공지 또는 이벤트 발송 기능 추가 예정입니다.
-            </Typography>
-          </Box>
-        )}
+        {ready && tab === 2 && <AdminNotifications />}
       </Box>
     </Layout>
   );


### PR DESCRIPTION
- 관리자 `/admin` 진입 시 탭이 선택되어도 콘텐츠가 렌더되지 않는 문제 수정
- 중복된 `<Route path="admin" ...>` 제거
- index route에 절대경로 리디렉션 적용 (`to="/admin/stats"`)
- 탭 클릭 시 URL 및 콘텐츠 정상 반영 확인 완료 ✨ feat: 관리자 알림 작성 및 전체 사용자에게 공지 전송 기능 구현

- 관리자 페이지에 공지/이벤트 알림 탭 추가
- 알림 등록, 수정, 삭제 가능 (제목, 내용, 종류 입력)
- 작성된 알림은 사용자에게 공개 API(`/api/notifications/public/`)로 제공
- 사용자 메뉴 내 알림 아이콘 클릭 시 최근 알림 최대 5개 확인 가능
- 긴 메시지는 모달로 전체 내용 확인 가능하게 구현